### PR TITLE
Autodetect *.tfvars files as Terraform

### DIFF
--- a/lib/rouge/lexers/terraform.rb
+++ b/lib/rouge/lexers/terraform.rb
@@ -11,7 +11,7 @@ module Rouge
 
       tag 'terraform'
       aliases 'tf'
-      filenames '*.tf'
+      filenames '*.tf', '*.tfvars'
 
       def self.keywords
         @keywords ||= Set.new %w(

--- a/spec/lexers/terraform_spec.rb
+++ b/spec/lexers/terraform_spec.rb
@@ -16,6 +16,7 @@ describe Rouge::Lexers::Terraform do
 
     it 'guesses by filename' do
       assert_guess :filename => 'foo.tf'
+      assert_guess :filename => 'foo.tfvars'
       deny_guess   :filename => 'foo'
     end
 


### PR DESCRIPTION
The `*.tfvars` files are used by Terraform and OpenTofu to hold variables and use the same syntax as *.tf files.